### PR TITLE
Prevent duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+* [PR-39](https://github.com/itk-dev/sysstatus/pull/39)
+  Prevented duplicating inactive reports and systems
 * [PR-38](https://github.com/itk-dev/sysstatus/pull/38)
   * Update importers
   * Add example data

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Make sure you have a set of JSON files for testing import Commands.
 ### Start Docker containers
 
 ```shell
-docker compose up -d
+docker compose up --detach
 docker compose exec phpfpm composer install
 docker compose exec phpfpm bin/console doctrine:migrations:migrate --no-interaction
 ```
@@ -37,7 +37,7 @@ docker compose exec phpfpm bin/console doctrine:migrations:migrate --no-interact
 ### Create a super admin user
 
 ```sh
-docker compose exec phpfpm bin/console SuperUser
+docker compose exec phpfpm bin/console app:user:create admin@example.com --password password --role=ROLE_SUPER_ADMIN
 ```
 
 ### Access the site
@@ -88,7 +88,7 @@ flowchart TD
  Theme[Theme]
  ThemeCategory[ThemeCategory]
  User[User]
- 
+
  fos_user_user_group{{JoinTable: fos_user_user_group }}
  group_system_themes{{JoinTable: group_system_themes }}
  group_report_themes{{JoinTable: group_report_themes }}
@@ -111,7 +111,7 @@ flowchart TD
  System --- |ManyToMany| SelServiceAFI
 
  Theme --- |ManyToOne| ThemeCategory
- 
+
  Answers --- |ManyToOne| Question
   Question -- JoinCollum Answers and Question --o Answers
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,7 +5,7 @@ dotenv: ['.env.local', '.env']
 
 vars:
   # https://taskfile.dev/reference/templating/
-  BASE_URL: '{{.TASK_BASE_URL | default .COMPOSE_SERVER_DOMAIN | default .COMPOSE_DOMAIN | default "https://hoeringsportal.local.itkdev.dk"}}'
+  BASE_URL: '{{.TASK_BASE_URL | default .COMPOSE_SERVER_DOMAIN | default .COMPOSE_DOMAIN | default "https://itstyr.local.itkdev.dk"}}'
   DOCKER_COMPOSE: '{{.TASK_DOCKER_COMPOSE | default "docker compose"}}'
 
 tasks:

--- a/src/Service/BaseImporter.php
+++ b/src/Service/BaseImporter.php
@@ -74,9 +74,9 @@ abstract class BaseImporter implements ImportInterface
     /**
      * @throws \Exception
      */
-    protected function convertDate(string $date): \DateTime
+    protected function convertDate(string $date): ?\DateTimeInterface
     {
-        return new \DateTime($date);
+        return empty($date) ? null : new \DateTimeImmutable($date);
     }
 
     /**
@@ -87,7 +87,7 @@ abstract class BaseImporter implements ImportInterface
     protected function convertSystemOwner(array $systemOwner): string
     {
         if (empty($systemOwner)) {
-          return '';
+            return '';
         }
 
         return $systemOwner[0]->LookupValue ?? '';

--- a/src/Service/BaseImporter.php
+++ b/src/Service/BaseImporter.php
@@ -6,6 +6,7 @@ use App\Repository\GroupRepository;
 use App\Repository\ReportRepository;
 use App\Repository\SystemRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 abstract class BaseImporter implements ImportInterface
@@ -21,6 +22,16 @@ abstract class BaseImporter implements ImportInterface
     ) {
         $this->url = $this->params->get('system_url') ?? '';
     }
+
+    public function import(string $src, ?ProgressBar $progressBar = null): void
+    {
+        // We need to be able to find all entities during import.
+        $this->entityManager->getFilters()->disable('entity_active');
+
+        $this->doImport($src, $progressBar);
+    }
+
+    abstract protected function doImport(string $src, ?ProgressBar $progressBar): void;
 
     protected function sanitizeText(string $str): ?string
     {

--- a/src/Service/ReportImporter.php
+++ b/src/Service/ReportImporter.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Helper\ProgressBar;
 
 class ReportImporter extends BaseImporter
 {
-    public function import(string $src, ?ProgressBar $progressBar = null): void
+    public function doImport(string $src, ?ProgressBar $progressBar = null): void
     {
         $json = file_get_contents($src);
         $entries = json_decode($json);

--- a/src/Service/SystemImporter.php
+++ b/src/Service/SystemImporter.php
@@ -24,7 +24,7 @@ class SystemImporter extends BaseImporter
         parent::__construct($reportRepository, $systemRepository, $groupRepository, $entityManager, $params);
     }
 
-    public function import(string $src, ?ProgressBar $progressBar = null): void
+    public function doImport(string $src, ?ProgressBar $progressBar = null): void
     {
         $json = file_get_contents($src);
         $entries = json_decode($json);


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/_#/tickets/showTicket/7131

#### Description

When importing systems and reports, we currently duplicate inactive items. This is due to [`EntityActiveFilter`](https://github.com/itk-dev/sysstatus/blob/develop/src/Doctrine/EntityActiveFilter.php) filtering out all inactive entities and thus the importer does not detect if an inactive items already exists (and creates a duplicate). 

We resolve this by 

- Disabling the doctrine filter in data importers

As added bonusses we also clean up a bit by

- Nullifying empty dates; they're currently set to “now”
- Cleaning up

---

We need to clean up the current data, and one way to do this (and probably also the best and most correct) is to delete all but the first row of any group of duplicated rows (sharing a `sys_internal_id`). This can be done by observing that the first row in a group is the one with the lowest ID ([`AUTO_INCREMENT`](https://dev.mysql.com/doc/refman/8.4/en/example-auto-increment.html) actually increments values!), and then using the following SQL incantations to clean up:

```sql
DELETE t1
FROM report t1 INNER JOIN report t2
WHERE t1.sys_internal_id = t2.sys_internal_id AND t1.id > t2.id;

DELETE t1
FROM system t1 INNER JOIN system t2
WHERE t1.sys_internal_id = t2.sys_internal_id AND t1.id > t2.id;
```

Shout out to https://stackoverflow.com/a/79695983 for coming up with this!
